### PR TITLE
Update CHAL.md

### DIFF
--- a/FalloutNV/Records/CHAL.md
+++ b/FalloutNV/Records/CHAL.md
@@ -9,11 +9,13 @@ Count | Subrecord | Name | Type | Info
 ------|-----------|------|------|-----
 + | EDID | Editor ID | cstring |
  | FULL | Name | cstring |
+ | ICON | Path to icon texture, when viewed in PipBoy | cstring | Optional
+ | MICO | Path to icon texture, when viewed in upper-left message | cstring | Optional
  | SCRI | Script | formid | FormID of a [SCPT](SCPT.md) record.
  | DESC | Description | cstring |
  | DATA | Data | struct |
- | SNAM | ?? | ?? |
- | XNAM | ?? | ?? |
+ | SNAM | Value3 | FormID | Depends on DATA.Type
+ | XNAM | Value4 | FormID | Depends on Data.Type
 
 ### DATA
 
@@ -23,14 +25,14 @@ Type | uint32 | Enum - see values below.
 Threshold | uint32 |
 Flags | uint32 | See values below.
 Interval | uint32 |
-?? | byte[2] |
-?? | byte[2] |
-?? | byte[4] |
+Value1 | byte[2] | Depends on Type
+Value2 | byte[2] | Depends on Type
+Value3 | byte[4] | Depends on Type
 
 #### Type Values
 
-Value | Meaning
-------|--------
+Value | Meaning |
+------|---------|
 0 | Kill From A Form List
 1 | Kill A Specific FormID
 2 | Kill Any In A Category


### PR DESCRIPTION
Added the new ICON and MICO subrecords. Tried to add the description for Type Values, but the table is too wide and the end result looks bad in browser. Seems that github theme does not take into account a large screen and persist into displaying only on half of the window, even when editing/viewing in full screen.